### PR TITLE
Handle token limits and errors (e.g., model max length)

### DIFF
--- a/services/summarizer.py
+++ b/services/summarizer.py
@@ -1,12 +1,15 @@
 """AI summarization service using Hugging Face transformers."""
 
+import logging
 from transformers import AutoTokenizer, pipeline
 
 
 MODEL = "facebook/bart-large-cnn"
+MAX_MODEL_TOKENS = 1024
 
-# Global summarizer instance for reuse
+# Global instances for reuse
 _summarizer = None
+_tokenizer = None
 
 
 def get_summarizer():
@@ -20,6 +23,14 @@ def get_summarizer():
     return _summarizer
 
 
+def get_tokenizer():
+    """Get or create the tokenizer."""
+    global _tokenizer
+    if _tokenizer is None:
+        _tokenizer = AutoTokenizer.from_pretrained(MODEL)
+    return _tokenizer
+
+
 def summarize_text(text: str, max_length: int = 150, min_length: int = 50) -> str:
     """Summarize the given text using BART model.
 
@@ -30,22 +41,26 @@ def summarize_text(text: str, max_length: int = 150, min_length: int = 50) -> st
 
     Returns:
         The summarized text
-
-    Raises:
-        ValueError: If summarization fails
     """
     if not text.strip():
         return ""
+
+    tokenizer = get_tokenizer()
+    tokens = tokenizer.encode(text)
+    if len(tokens) > MAX_MODEL_TOKENS:
+        tokens = tokens[:MAX_MODEL_TOKENS]
+        text = tokenizer.decode(tokens)
 
     summarizer = get_summarizer()
     try:
         summary = summarizer(text, max_length=max_length, min_length=min_length, do_sample=False)
         return summary[0]['summary_text']
     except Exception as e:
-        raise ValueError(f"Summarization failed: {e}")
+        logging.error(f"Error summarizing text: {e}")
+        return ""
 
 
-def chunk_text(text: str, max_tokens: int = 1000, min_tokens: int = 500) -> list[str]:
+def chunk_text(text: str, max_tokens: int = 900, min_tokens: int = 500) -> list[str]:
     """Split text into chunks based on token count.
 
     Args:
@@ -59,7 +74,7 @@ def chunk_text(text: str, max_tokens: int = 1000, min_tokens: int = 500) -> list
     if not text.strip():
         return []
 
-    tokenizer = AutoTokenizer.from_pretrained(MODEL)
+    tokenizer = get_tokenizer()
     tokens = tokenizer.encode(text, add_special_tokens=False)
 
     chunks = []


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
This PR implements issue #20: Handle token limits and errors (e.g., model max length).

### Changes:
- Added `MAX_MODEL_TOKENS` constant set to 1024 for BART model
- Added global tokenizer instance to avoid reloading
- Modified `summarize_text` to truncate input text exceeding token limits
- Added error handling with logging for summarization failures instead of raising exceptions
- Reduced default `max_tokens` in `chunk_text` to 900 for safety buffer
- Updated `chunk_text` to use shared tokenizer instance

### Technical Details:
The implementation ensures that texts are truncated to the model's maximum token capacity before summarization, preventing runtime errors. Error handling logs failures and returns empty strings as safe fallbacks. Chunking uses a conservative limit to maintain quality while avoiding token overflow.
EOF
)