### PR TITLE
Implement save_summary function

### DIFF
--- a/services/storage.py
+++ b/services/storage.py
@@ -3,8 +3,9 @@
 import hashlib
 import json
 import gzip
+import logging
 from pathlib import Path
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 from typing import Optional
 
 # Storage directory in user's home
@@ -31,15 +32,39 @@ def get_file_path(book_path: str) -> Path:
     book_hash = hashlib.md5(book_path.encode('utf-8')).hexdigest()
     return STORAGE_DIR / f"{book_hash}.summary.json.gz"
 
-# Placeholder functions for future implementation
 def save_summary(metadata: dict, summary: str) -> None:
     """Save summary data to compressed JSON file.
 
     Args:
         metadata: Dict with title, author, path, timestamp
         summary: Summary text
+
+    Raises:
+        ValueError: If metadata is invalid
     """
-    pass
+    try:
+        title = metadata['title']
+        author = metadata['author']
+        path = metadata['path']
+        timestamp = metadata['timestamp']
+    except KeyError as e:
+        raise ValueError(f"Missing metadata field: {e}")
+
+    data = SummaryData(title=title, author=author, path=path, timestamp=timestamp, summary=summary)
+    file_path = get_file_path(path)
+
+    # Ensure directory exists
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    data_dict = asdict(data)
+    json_str = json.dumps(data_dict, ensure_ascii=False)
+
+    try:
+        with gzip.open(file_path, 'wt', encoding='utf-8') as f:
+            f.write(json_str)
+    except Exception as e:
+        logging.error(f"Failed to save summary for {path}: {e}")
+        raise
 
 def load_summary(book_path: str) -> Optional[SummaryData]:
     """Load summary data from compressed JSON file.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
This PR implements issue #52: Implement save_summary function.

### Changes:
- Added logging and asdict imports to services/storage.py
- Implemented save_summary function with metadata validation (title, author, path, timestamp)
- Creates SummaryData instance and serializes to compressed JSON using gzip
- Ensures storage directory exists and handles file I/O errors with logging
- Validates metadata fields and raises ValueError for missing keys

### Technical Details:
The function compresses summary data using gzip for efficient storage, saves to a hash-based filename in ~/.brief/summaries/, and includes robust error handling for validation and file operations. This completes the save functionality for the storage system.
EOF
)